### PR TITLE
Optionally commit offsets synchronously on partition revoke

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -270,6 +270,11 @@ ThisBuild / mimaBinaryIssueFilters ++= {
     ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaConsumer.settings"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ConsumerSettings.withMaxParallelism"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ConsumerSettings.maxParallelism"),
+    // `commitOnRevoke` settings flag, added (opt-in) in 4.1. `ConsumerSettings` is a sealed
+    // abstract class (no external implementors), so adding these abstract methods is safe; the
+    // `ConsumerSettingsImpl` copy/this/apply filters below already cover the extra field.
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ConsumerSettings.commitOnRevoke"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ConsumerSettings.withCommitOnRevoke"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.copy"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.this"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.apply"),

--- a/build.sbt
+++ b/build.sbt
@@ -270,9 +270,7 @@ ThisBuild / mimaBinaryIssueFilters ++= {
     ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaConsumer.settings"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ConsumerSettings.withMaxParallelism"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ConsumerSettings.maxParallelism"),
-    // `commitOnRevoke` settings flag, added (opt-in) in 4.1. `ConsumerSettings` is a sealed
-    // abstract class (no external implementors), so adding these abstract methods is safe; the
-    // `ConsumerSettingsImpl` copy/this/apply filters below already cover the extra field.
+    // New commitOnRevoke settings; safe to add because ConsumerSettings is sealed.
     ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ConsumerSettings.commitOnRevoke"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ConsumerSettings.withCommitOnRevoke"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.copy"),

--- a/build.sbt
+++ b/build.sbt
@@ -270,7 +270,6 @@ ThisBuild / mimaBinaryIssueFilters ++= {
     ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaConsumer.settings"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ConsumerSettings.withMaxParallelism"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ConsumerSettings.maxParallelism"),
-    // New commitOnRevoke settings; safe to add because ConsumerSettings is sealed.
     ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ConsumerSettings.commitOnRevoke"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ConsumerSettings.withCommitOnRevoke"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.copy"),

--- a/modules/core/src/main/scala/fs2/kafka/ConsumerSettings.scala
+++ b/modules/core/src/main/scala/fs2/kafka/ConsumerSettings.scala
@@ -414,6 +414,27 @@ sealed abstract class ConsumerSettings[F[_], K, V] {
     */
   def maxParallelism: Int
 
+  /**
+    * Whether, when partitions are revoked, the offsets of already-requested commits for those
+    * partitions should be committed synchronously (via `commitSync`) from within the rebalance
+    * listener, while the consumer still owns them.
+    *
+    * The default is `false`. When `false`, the behaviour is unchanged: commits are issued
+    * asynchronously and an in-flight commit may be lost if a rebalance or shutdown happens before
+    * it is acknowledged, leading to records being re-delivered (at-least-once).
+    *
+    * When `true`, the latest requested offset per partition is remembered and re-committed
+    * synchronously on revoke, which narrows that duplicate-delivery window. It does not eliminate
+    * duplicates entirely (records consumed but not yet committed are still re-delivered), and is
+    * best combined with [[RebalanceRevokeMode.Graceful]] and/or idempotent processing.
+    */
+  def commitOnRevoke: Boolean
+
+  /**
+    * Creates a new [[ConsumerSettings]] with the specified [[commitOnRevoke]] flag.
+    */
+  def withCommitOnRevoke(commitOnRevoke: Boolean): ConsumerSettings[F, K, V]
+
 }
 
 object ConsumerSettings {
@@ -431,7 +452,8 @@ object ConsumerSettings {
     override val recordMetadata: ConsumerRecord[K, V] => String,
     override val maxPrefetchBatches: Int,
     override val rebalanceRevokeMode: RebalanceRevokeMode,
-    override val maxParallelism: Int
+    override val maxParallelism: Int,
+    override val commitOnRevoke: Boolean
   ) extends ConsumerSettings[F, K, V] {
 
     override def withMaxParallelism(maxParallelism: Int): ConsumerSettings[F, K, V] =
@@ -568,6 +590,9 @@ object ConsumerSettings {
     ): ConsumerSettings[F, K, V] =
       copy(rebalanceRevokeMode = rebalanceRevokeMode)
 
+    override def withCommitOnRevoke(commitOnRevoke: Boolean): ConsumerSettings[F, K, V] =
+      copy(commitOnRevoke = commitOnRevoke)
+
     override def toString: String =
       s"ConsumerSettings(closeTimeout = $closeTimeout, commitTimeout = $commitTimeout, pollInterval = $pollInterval, pollTimeout = $pollTimeout, commitRecovery = $commitRecovery)"
 
@@ -603,7 +628,8 @@ object ConsumerSettings {
       recordMetadata = _ => OffsetFetchResponse.NO_METADATA,
       maxPrefetchBatches = 2,
       rebalanceRevokeMode = RebalanceRevokeMode.Eager,
-      maxParallelism = Int.MaxValue
+      maxParallelism = Int.MaxValue,
+      commitOnRevoke = false
     )
 
   def apply[F[_], K, V](

--- a/modules/core/src/main/scala/fs2/kafka/ConsumerSettings.scala
+++ b/modules/core/src/main/scala/fs2/kafka/ConsumerSettings.scala
@@ -415,18 +415,14 @@ sealed abstract class ConsumerSettings[F[_], K, V] {
   def maxParallelism: Int
 
   /**
-    * Whether, when partitions are revoked, the offsets of already-requested commits for those
-    * partitions should be committed synchronously (via `commitSync`) from within the rebalance
-    * listener, while the consumer still owns them.
+    * When `true`, offsets already passed to `commit` for the revoked partitions are committed
+    * synchronously from the rebalance listener, before we lose those partitions. This reduces
+    * duplicate deliveries around a rebalance or shutdown, where an asynchronous commit that has not
+    * been acknowledged yet would otherwise be lost.
     *
-    * The default is `false`. When `false`, the behaviour is unchanged: commits are issued
-    * asynchronously and an in-flight commit may be lost if a rebalance or shutdown happens before
-    * it is acknowledged, leading to records being re-delivered (at-least-once).
-    *
-    * When `true`, the latest requested offset per partition is remembered and re-committed
-    * synchronously on revoke, which narrows that duplicate-delivery window. It does not eliminate
-    * duplicates entirely (records consumed but not yet committed are still re-delivered), and is
-    * best combined with [[RebalanceRevokeMode.Graceful]] and/or idempotent processing.
+    * It does not remove duplicates completely: records that were consumed but not yet committed are
+    * still redelivered. Combine it with [[RebalanceRevokeMode.Graceful]] or idempotent processing
+    * for stronger guarantees. Defaults to `false`.
     */
   def commitOnRevoke: Boolean
 

--- a/modules/core/src/main/scala/fs2/kafka/ConsumerSettings.scala
+++ b/modules/core/src/main/scala/fs2/kafka/ConsumerSettings.scala
@@ -414,21 +414,8 @@ sealed abstract class ConsumerSettings[F[_], K, V] {
     */
   def maxParallelism: Int
 
-  /**
-    * When `true`, offsets already passed to `commit` for the revoked partitions are committed
-    * synchronously from the rebalance listener, before we lose those partitions. This reduces
-    * duplicate deliveries around a rebalance or shutdown, where an asynchronous commit that has not
-    * been acknowledged yet would otherwise be lost.
-    *
-    * It does not remove duplicates completely: records that were consumed but not yet committed are
-    * still redelivered. Combine it with [[RebalanceRevokeMode.Graceful]] or idempotent processing
-    * for stronger guarantees. Defaults to `false`.
-    */
   def commitOnRevoke: Boolean
 
-  /**
-    * Creates a new [[ConsumerSettings]] with the specified [[commitOnRevoke]] flag.
-    */
   def withCommitOnRevoke(commitOnRevoke: Boolean): ConsumerSettings[F, K, V]
 
 }

--- a/modules/core/src/main/scala/fs2/kafka/ConsumerSettings.scala
+++ b/modules/core/src/main/scala/fs2/kafka/ConsumerSettings.scala
@@ -414,8 +414,21 @@ sealed abstract class ConsumerSettings[F[_], K, V] {
     */
   def maxParallelism: Int
 
+  /**
+    * Whether offsets already passed to `commit` should be committed synchronously when their
+    * partitions are revoked, from within the rebalance listener, before the partitions are lost.
+    * This reduces duplicate deliveries around rebalances and shutdown, where an asynchronous commit
+    * that has not yet been acknowledged would otherwise be lost. It does not remove duplicates
+    * entirely, since records consumed but not yet committed are still redelivered; combine it with
+    * [[RebalanceRevokeMode.Graceful]] or idempotent processing for stronger guarantees.<br><br>
+    *
+    * The default value is `false`.
+    */
   def commitOnRevoke: Boolean
 
+  /**
+    * Creates a new [[ConsumerSettings]] with the specified [[commitOnRevoke]].
+    */
   def withCommitOnRevoke(commitOnRevoke: Boolean): ConsumerSettings[F, K, V]
 
 }

--- a/modules/core/src/main/scala/fs2/kafka/internal/LogEntry.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/LogEntry.scala
@@ -18,6 +18,7 @@ import fs2.kafka.internal.syntax.*
 import fs2.kafka.internal.LogLevel.*
 import fs2.kafka.CommittableConsumerRecord
 
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
 
 sealed abstract private[kafka] class LogEntry {
@@ -121,6 +122,26 @@ private[kafka] object LogEntry {
 
     override def message: String =
       s"Consuming streams did not signal processing completion of [$group]. Current state [$groupState]."
+
+  }
+
+  final case class CommittedOffsetsOnRevoke(
+    revoked: Set[TopicPartition],
+    offsets: Map[TopicPartition, OffsetAndMetadata],
+    result: Either[Throwable, Unit]
+  ) extends LogEntry {
+
+    override def level: LogLevel = Info
+
+    override def message: String =
+      result match {
+        case Right(()) =>
+          s"Committed offsets [${offsets
+              .mkString(", ")}] synchronously on revoke of partitions [${revoked.mkString(", ")}]."
+        case Left(e) =>
+          s"Failed to commit offsets [${offsets
+              .mkString(", ")}] synchronously on revoke of partitions [${revoked.mkString(", ")}]: $e."
+      }
 
   }
 

--- a/modules/core/src/main/scala/fs2/kafka/internal/WithConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/WithConsumer.scala
@@ -15,7 +15,20 @@ import fs2.kafka.internal.syntax.*
 import org.apache.kafka.clients.consumer.CloseOptions
 
 sealed abstract private[kafka] class WithConsumer[F[_]] {
+
   def blocking[A](f: KafkaByteConsumer => A): F[A]
+
+  /**
+    * Runs `f` on the current thread, directly on the underlying consumer, bypassing the
+    * single-threaded blocking context used by [[blocking]].
+    *
+    * This is ONLY safe to call from within a `ConsumerRebalanceListener` callback. Those callbacks
+    * are invoked by Kafka on the consumer's polling thread (inside `poll`), so the consumer may be
+    * accessed reentrantly from there, and routing through [[blocking]] would instead deadlock by
+    * submitting to the single-threaded context that is already occupied by the in-progress `poll`.
+    */
+  def synchronouslyDuringRebalance[A](f: KafkaByteConsumer => A): A
+
 }
 
 private[kafka] object WithConsumer {
@@ -36,6 +49,9 @@ private[kafka] object WithConsumer {
 
             override def blocking[A](f: KafkaByteConsumer => A): F[A] =
               b(f(consumer))
+
+            override def synchronouslyDuringRebalance[A](f: KafkaByteConsumer => A): A =
+              f(consumer)
 
           }
         }

--- a/modules/core/src/main/scala/fs2/kafka/internal/WithConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/WithConsumer.scala
@@ -18,14 +18,6 @@ sealed abstract private[kafka] class WithConsumer[F[_]] {
 
   def blocking[A](f: KafkaByteConsumer => A): F[A]
 
-  /**
-    * Runs `f` on the underlying consumer directly, on the calling thread, without going through the
-    * single-threaded blocking context that [[blocking]] uses.
-    *
-    * Only call this from a `ConsumerRebalanceListener` callback. Kafka runs those callbacks on the
-    * polling thread while `poll` is in progress, so the consumer can be used from there directly.
-    * Using [[blocking]] instead would deadlock, since it submits to the context `poll` is holding.
-    */
   def synchronouslyDuringRebalance[A](f: KafkaByteConsumer => A): A
 
 }

--- a/modules/core/src/main/scala/fs2/kafka/internal/WithConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/WithConsumer.scala
@@ -19,13 +19,12 @@ sealed abstract private[kafka] class WithConsumer[F[_]] {
   def blocking[A](f: KafkaByteConsumer => A): F[A]
 
   /**
-    * Runs `f` on the current thread, directly on the underlying consumer, bypassing the
-    * single-threaded blocking context used by [[blocking]].
+    * Runs `f` on the underlying consumer directly, on the calling thread, without going through the
+    * single-threaded blocking context that [[blocking]] uses.
     *
-    * This is ONLY safe to call from within a `ConsumerRebalanceListener` callback. Those callbacks
-    * are invoked by Kafka on the consumer's polling thread (inside `poll`), so the consumer may be
-    * accessed reentrantly from there, and routing through [[blocking]] would instead deadlock by
-    * submitting to the single-threaded context that is already occupied by the in-progress `poll`.
+    * Only call this from a `ConsumerRebalanceListener` callback. Kafka runs those callbacks on the
+    * polling thread while `poll` is in progress, so the consumer can be used from there directly.
+    * Using [[blocking]] instead would deadlock, since it submits to the context `poll` is holding.
     */
   def synchronouslyDuringRebalance[A](f: KafkaByteConsumer => A): A
 

--- a/modules/core/src/main/scala/fs2/kafka/internal/actor/KafkaConsumerActor.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/actor/KafkaConsumerActor.scala
@@ -10,6 +10,7 @@ import java.time.Duration
 import java.util
 
 import scala.collection.immutable.SortedSet
+import scala.util.control.NonFatal
 import scala.util.matching.Regex
 
 import cats.data.NonEmptyList
@@ -91,7 +92,9 @@ final private[kafka] class KafkaConsumerActor[F[_], K, V](
   private[this] val maxPrefetch: Int      = settings.maxPrefetchBatches
 
   val consumerRebalanceListener: ConsumerRebalanceListener = new ConsumerRebalanceListener {
-    override def onPartitionsRevoked(partitions: util.Collection[TopicPartition]): Unit =
+    override def onPartitionsRevoked(partitions: util.Collection[TopicPartition]): Unit = {
+      if (settings.commitOnRevoke)
+        commitOnRevokeSync(partitions.asScala.toSet)
       dispatcher.unsafeRunSync {
         state.evalUpdate { state =>
           val currentAssignment = state.partitionGroupState.keys.toList.flatten.toSet
@@ -99,6 +102,7 @@ final private[kafka] class KafkaConsumerActor[F[_], K, V](
           alignPartitionState(targetAssignment, state.partitionGroupState).map(state.withGroupState)
         }
       }
+    }
 
     override def onPartitionsAssigned(partitions: util.Collection[TopicPartition]): Unit =
       dispatcher.unsafeRunSync {
@@ -381,7 +385,39 @@ final private[kafka] class KafkaConsumerActor[F[_], K, V](
       .handleErrorWith(e => F.delay(callback(Left(e))))
 
   private[this] def commit(request: Request.Commit[F]): F[Unit] =
-    commitAsync(request.offsets, request.callback)
+    state
+      .update(_.withRequestedCommitOffsets(request.offsets))
+      .whenA(settings.commitOnRevoke) >> commitAsync(request.offsets, request.callback)
+
+  /**
+    * Best-effort, synchronous commit of the most recently requested offsets for the partitions
+    * being revoked, performed from within `onPartitionsRevoked` while we still own them.
+    *
+    * Kafka invokes the rebalance listener on the consumer's polling thread, from inside `poll`. The
+    * `commitSync` therefore goes through [[WithConsumer.synchronouslyDuringRebalance]] — a direct,
+    * reentrant call on the Java consumer on that same thread — rather than `withConsumer.blocking`,
+    * which would submit to the single-threaded blocking context already occupied by `poll` and
+    * deadlock. State access is bounced onto the effect runtime (it is thread-safe), but the
+    * consumer call itself must stay on the polling thread.
+    *
+    * Failures are logged and swallowed: this only narrows the duplicate-delivery window, and the
+    * consumer remains at-least-once.
+    */
+  private[this] def commitOnRevokeSync(revoked: Set[TopicPartition]): Unit = {
+    val offsets = dispatcher.unsafeRunSync(state.modify(_.removeRequestedCommitOffsets(revoked)))
+    if (offsets.nonEmpty) {
+      val result =
+        try {
+          withConsumer.synchronouslyDuringRebalance(
+            _.commitSync(offsets.asJava, settings.commitTimeout.toJava)
+          )
+          ().asRight[Throwable]
+        } catch {
+          case NonFatal(e) => Left(e)
+        }
+      dispatcher.unsafeRunSync(logging.log(CommittedOffsetsOnRevoke(revoked, offsets, result)))
+    }
+  }
 
   private[this] def manualCommitSync(request: Request.ManualCommitSync[F]): F[Unit] = {
     val commit =

--- a/modules/core/src/main/scala/fs2/kafka/internal/actor/KafkaConsumerActor.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/actor/KafkaConsumerActor.scala
@@ -390,18 +390,14 @@ final private[kafka] class KafkaConsumerActor[F[_], K, V](
       .whenA(settings.commitOnRevoke) >> commitAsync(request.offsets, request.callback)
 
   /**
-    * Best-effort, synchronous commit of the most recently requested offsets for the partitions
-    * being revoked, performed from within `onPartitionsRevoked` while we still own them.
+    * Commits the last requested offsets for the partitions being revoked, synchronously, from
+    * `onPartitionsRevoked` while we still own them.
     *
-    * Kafka invokes the rebalance listener on the consumer's polling thread, from inside `poll`. The
-    * `commitSync` therefore goes through [[WithConsumer.synchronouslyDuringRebalance]] — a direct,
-    * reentrant call on the Java consumer on that same thread — rather than `withConsumer.blocking`,
-    * which would submit to the single-threaded blocking context already occupied by `poll` and
-    * deadlock. State access is bounced onto the effect runtime (it is thread-safe), but the
-    * consumer call itself must stay on the polling thread.
-    *
-    * Failures are logged and swallowed: this only narrows the duplicate-delivery window, and the
-    * consumer remains at-least-once.
+    * The listener runs on the polling thread, so the commit goes through
+    * [[WithConsumer.synchronouslyDuringRebalance]] (a direct call on that thread) rather than
+    * `withConsumer.blocking`, which would deadlock against the ongoing `poll`. Reading the state
+    * goes through the dispatcher, which is safe to do. Errors are logged and ignored: this only
+    * reduces duplicates and does not change the at-least-once guarantee.
     */
   private[this] def commitOnRevokeSync(revoked: Set[TopicPartition]): Unit = {
     val offsets = dispatcher.unsafeRunSync(state.modify(_.removeRequestedCommitOffsets(revoked)))

--- a/modules/core/src/main/scala/fs2/kafka/internal/actor/KafkaConsumerActor.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/actor/KafkaConsumerActor.scala
@@ -389,16 +389,6 @@ final private[kafka] class KafkaConsumerActor[F[_], K, V](
       .update(_.withRequestedCommitOffsets(request.offsets))
       .whenA(settings.commitOnRevoke) >> commitAsync(request.offsets, request.callback)
 
-  /**
-    * Commits the last requested offsets for the partitions being revoked, synchronously, from
-    * `onPartitionsRevoked` while we still own them.
-    *
-    * The listener runs on the polling thread, so the commit goes through
-    * [[WithConsumer.synchronouslyDuringRebalance]] (a direct call on that thread) rather than
-    * `withConsumer.blocking`, which would deadlock against the ongoing `poll`. Reading the state
-    * goes through the dispatcher, which is safe to do. Errors are logged and ignored: this only
-    * reduces duplicates and does not change the at-least-once guarantee.
-    */
   private[this] def commitOnRevokeSync(revoked: Set[TopicPartition]): Unit = {
     val offsets = dispatcher.unsafeRunSync(state.modify(_.removeRequestedCommitOffsets(revoked)))
     if (offsets.nonEmpty) {

--- a/modules/core/src/main/scala/fs2/kafka/internal/actor/State.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/actor/State.scala
@@ -13,6 +13,7 @@ import cats.effect.Deferred
 import fs2.kafka.CommittableConsumerRecord
 import fs2.Chunk
 
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
 
 private[kafka] object State {
@@ -21,7 +22,8 @@ private[kafka] object State {
     State[F, K, V](
       Map.empty,
       false,
-      false
+      false,
+      Map.empty
     )
 
 }
@@ -46,7 +48,8 @@ final private[kafka] case class PartitionGroupState[F[_], K, V](
 final private[kafka] case class State[F[_], K, V](
   partitionGroupState: Map[Set[TopicPartition], PartitionGroupState[F, K, V]],
   subscribed: Boolean,
-  streaming: Boolean
+  streaming: Boolean,
+  requestedCommitOffsets: Map[TopicPartition, OffsetAndMetadata]
 )(implicit
   F: Async[F]
 ) {
@@ -63,6 +66,31 @@ final private[kafka] case class State[F[_], K, V](
     copy(streaming = true)
 
   def withNotStreaming(): State[F, K, V] = copy(streaming = false)
+
+  /**
+    * Remembers the latest requested commit offset per partition, so that — if those partitions are
+    * revoked before the asynchronous commit is acknowledged — they can be committed synchronously
+    * from within the rebalance listener. Keeps the highest offset seen per partition.
+    */
+  def withRequestedCommitOffsets(
+    offsets: Map[TopicPartition, OffsetAndMetadata]
+  ): State[F, K, V] =
+    copy(requestedCommitOffsets = offsets.foldLeft(requestedCommitOffsets) {
+      case (acc, (partition, offsetAndMetadata)) =>
+        val isNewer = acc.get(partition).forall(_.offset < offsetAndMetadata.offset)
+        if (isNewer) acc.updated(partition, offsetAndMetadata) else acc
+    })
+
+  /**
+    * Removes and returns the tracked commit offsets for the given (revoked) partitions.
+    */
+  def removeRequestedCommitOffsets(
+    revoked: Set[TopicPartition]
+  ): (State[F, K, V], Map[TopicPartition, OffsetAndMetadata]) = {
+    val (toCommit, retained) =
+      requestedCommitOffsets.partition { case (partition, _) => revoked.contains(partition) }
+    (copy(requestedCommitOffsets = retained), toCommit)
+  }
 
   override def toString: String =
     s"State(partitionGroupState = $partitionGroupState, subscribed = $subscribed, streaming = $streaming)"

--- a/modules/core/src/main/scala/fs2/kafka/internal/actor/State.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/actor/State.scala
@@ -68,9 +68,8 @@ final private[kafka] case class State[F[_], K, V](
   def withNotStreaming(): State[F, K, V] = copy(streaming = false)
 
   /**
-    * Remembers the latest requested commit offset per partition, so that — if those partitions are
-    * revoked before the asynchronous commit is acknowledged — they can be committed synchronously
-    * from within the rebalance listener. Keeps the highest offset seen per partition.
+    * Records the latest requested offset per partition, so it can be committed on revoke if the
+    * asynchronous commit has not landed yet. Keeps the highest offset per partition.
     */
   def withRequestedCommitOffsets(
     offsets: Map[TopicPartition, OffsetAndMetadata]
@@ -82,7 +81,7 @@ final private[kafka] case class State[F[_], K, V](
     })
 
   /**
-    * Removes and returns the tracked commit offsets for the given (revoked) partitions.
+    * Drops and returns the tracked offsets for the revoked partitions.
     */
   def removeRequestedCommitOffsets(
     revoked: Set[TopicPartition]

--- a/modules/core/src/main/scala/fs2/kafka/internal/actor/State.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/actor/State.scala
@@ -67,10 +67,6 @@ final private[kafka] case class State[F[_], K, V](
 
   def withNotStreaming(): State[F, K, V] = copy(streaming = false)
 
-  /**
-    * Records the latest requested offset per partition, so it can be committed on revoke if the
-    * asynchronous commit has not landed yet. Keeps the highest offset per partition.
-    */
   def withRequestedCommitOffsets(
     offsets: Map[TopicPartition, OffsetAndMetadata]
   ): State[F, K, V] =
@@ -80,9 +76,6 @@ final private[kafka] case class State[F[_], K, V](
         if (isNewer) acc.updated(partition, offsetAndMetadata) else acc
     })
 
-  /**
-    * Drops and returns the tracked offsets for the revoked partitions.
-    */
   def removeRequestedCommitOffsets(
     revoked: Set[TopicPartition]
   ): (State[F, K, V], Map[TopicPartition, OffsetAndMetadata]) = {

--- a/modules/core/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
@@ -289,6 +289,14 @@ final class ConsumerSettingsSpec extends BaseSpec {
         settings.show == settings.toString
       }
     }
+
+    it("should default commitOnRevoke to false and provide withCommitOnRevoke") {
+      assert {
+        !settings.commitOnRevoke &&
+        settings.withCommitOnRevoke(true).commitOnRevoke &&
+        !settings.withCommitOnRevoke(true).withCommitOnRevoke(false).commitOnRevoke
+      }
+    }
   }
 
   val settings =

--- a/modules/core/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
@@ -75,6 +75,51 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
       }
     }
 
+    it("should commit offsets synchronously on revoke when commitOnRevoke is enabled") {
+      withTopic { topic =>
+        createCustomTopic(topic, partitions = 1)
+        val produced = (0 until 5).map(n => s"key-$n" -> s"value->$n")
+        publishToKafka(topic, produced)
+
+        val settings =
+          consumerSettings[IO]
+            .withGroupId(s"commit-on-revoke-${UUID.randomUUID()}")
+            .withCommitOnRevoke(true)
+
+        // The first consumer processes and commits every record, then shuts down. Closing it
+        // triggers `onPartitionsRevoked`, where the tracked offsets are committed synchronously
+        // (directly on the Java consumer, while the partition is still owned).
+        val consumedFirst =
+          KafkaConsumer
+            .stream(settings)
+            .subscribeTo(topic)
+            .records
+            .evalMap(committable => committable.offset.commit.as(committable.record.key))
+            .take(produced.size.toLong)
+            .compile
+            .toVector
+
+        // A second consumer in the same group must then find nothing left to consume.
+        val consumedSecond =
+          KafkaConsumer
+            .stream(settings)
+            .subscribeTo(topic)
+            .records
+            .map(_.record.key)
+            .interruptAfter(10.seconds)
+            .compile
+            .toVector
+
+        val (first, second) =
+          (for {
+            a <- consumedFirst
+            b <- consumedSecond
+          } yield (a, b)).unsafeRunSync()
+
+        assert(first.size.toLong == produced.size.toLong && second.isEmpty)
+      }
+    }
+
     def testMultipleConsumersCorrectConsumption(
       customizeSettings: ConsumerSettings[IO, String, String] => ConsumerSettings[
         IO,

--- a/modules/core/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
@@ -86,8 +86,6 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
             .withGroupId(s"commit-on-revoke-${UUID.randomUUID()}")
             .withCommitOnRevoke(true)
 
-        // First consumer commits every record and then shuts down. On close, onPartitionsRevoked
-        // commits the tracked offsets synchronously while it still owns the partition.
         val consumedFirst =
           KafkaConsumer
             .stream(settings)
@@ -98,7 +96,6 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
             .compile
             .toVector
 
-        // Second consumer in the same group should then have nothing left to read.
         val consumedSecond =
           KafkaConsumer
             .stream(settings)

--- a/modules/core/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
@@ -86,9 +86,8 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
             .withGroupId(s"commit-on-revoke-${UUID.randomUUID()}")
             .withCommitOnRevoke(true)
 
-        // The first consumer processes and commits every record, then shuts down. Closing it
-        // triggers `onPartitionsRevoked`, where the tracked offsets are committed synchronously
-        // (directly on the Java consumer, while the partition is still owned).
+        // First consumer commits every record and then shuts down. On close, onPartitionsRevoked
+        // commits the tracked offsets synchronously while it still owns the partition.
         val consumedFirst =
           KafkaConsumer
             .stream(settings)
@@ -99,7 +98,7 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
             .compile
             .toVector
 
-        // A second consumer in the same group must then find nothing left to consume.
+        // Second consumer in the same group should then have nothing left to read.
         val consumedSecond =
           KafkaConsumer
             .stream(settings)


### PR DESCRIPTION
## Human TLDR

During rebalances/shutdown, fs2-kafka can re-process messages: offsets for records we already handled are committed asynchronously and may not land before the partition is revoked, so the next pod/consumer re-reads them.

This PR adds an opt-in `CommitOnRevoke`: when a partition is revoked, it synchronously commits the offsets already requested via `.commit` (directly on the consumer, inside the rebalance callback) before it loses the partition.

It removes duplicates from _processed but uncommitted_ records only. It does not drain unprocessed in-flight records (that is Graceful mode's responsibility, right?) and is not a correctness guarantee on its own (application itself is responsible for dedup/idempotency). Default is off.
