### PR TITLE
Fail permit-based operations with ConsumerShutdownException after consumer termination

### DIFF
--- a/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -334,8 +334,9 @@ object KafkaConsumer {
           .flatMap { deferred =>
             requests.offer(
               Request.WithPermit(fa, deferred.complete(_: Either[Throwable, A]).void)
-            ) >> deferred.get.rethrow
+            ) >> F.race(awaitTermination.as(ConsumerShutdownException()), deferred.get.rethrow)
           }
+          .rethrow
 
       override def subscribe(regex: Regex): F[Unit] =
         withPermit(actor.subscribe(regex))

--- a/modules/core/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
@@ -245,6 +245,24 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
       }
     }
 
+    it("should fail subscription operations instead of hanging when terminated") {
+      withTopic { topic =>
+        val result =
+          KafkaConsumer
+            .stream(consumerSettings[IO])
+            .subscribeTo(topic)
+            .evalTap(_.terminate)
+            .evalTap(_.awaitTermination)
+            .evalMap(_.unsubscribe.attempt)
+            .compile
+            .lastOrError
+            .timeout(30.seconds)
+            .unsafeRunSync()
+
+        assert(result.left.exists(_.isInstanceOf[ConsumerShutdownException]))
+      }
+    }
+
     it("should fail with an error if not subscribed or assigned") {
       withTopic { topic =>
         createCustomTopic(topic, partitions = 3)


### PR DESCRIPTION
## Problem

Once the background consumer fiber has died (any exception thrown by `poll`), the permit-based operations `subscribe`, `unsubscribe` and `assign` block forever. `withPermit` offers a `Request.WithPermit` to the requests queue and then waits on a `Deferred` that nothing will ever complete, because the actor loop that services the queue is gone.

The `request` helper used by the commit path already handles this case by racing `awaitTermination`, so committing on a dead consumer fails fast with `ConsumerShutdownException` while unsubscribing on one hangs forever. That shutdown guarantee dates back to #66 ("All KafkaConsumer requests now check to ensure the consumer has not already shutdown") and was lost for the permit-based operations introduced in #906.

## Why it matters

The idiomatic place to call `unsubscribe` is a `Resource` / `bracket` finalizer around the record stream. fs2 runs finalizers before surfacing the stream's error, and finalizers are uncancelable. So when the poll loop dies (for example an out-of-range fetch under `AutoOffsetReset.None`):

1. the record streams are correctly interrupted via `awaitTermination`,
2. the scope closes and runs the finalizer,
3. `unsubscribe` deadlocks,
4. the original error is never raised, and because the finalizer is uncancelable, no surrounding `.timeout`, fiber cancel or `IO.race` can fire either.

## Fix

Mirror the `request` helper's race in `withPermit`:

```scala
requests.offer(
  Request.WithPermit(fa, deferred.complete(_: Either[Throwable, A]).void)
) >> F.race(awaitTermination.as(ConsumerShutdownException()), deferred.get.rethrow)
```

Behaviour matches the commit path: if the fiber died with an error, `awaitTermination` rethrows it; if the consumer terminated normally, the operation fails with `ConsumerShutdownException`. Live consumers are unaffected, the deferred wins the race.